### PR TITLE
Fixing binder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/0.8.0?urlpath=tree%2Fdoc%2Fusage%2Fentry_interactions.md)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/0.8.0?labpath=tree%2Fdoc%2Findex.md)
 [![DOI](https://zenodo.org/badge/637997870.svg)](https://zenodo.org/badge/latestdoi/637997870)
 
 This module provides a Python library to interact with a collection of

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,5 +9,3 @@ dependencies:
   - pip
   - python>=3.9,<3.11
   - unitpackage==0.8.0
-  - pip:
-    - bash_kernel

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,6 @@ dependencies:
   - notebook
   - pip
   - python>=3.9,<3.11
-  - unitpackage==0.8.0
   - pip:
+    - unitpackage==0.8.0
     - bash_kernel

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,6 @@ dependencies:
   - notebook
   - pip
   - python>=3.9,<3.11
+  - unitpackage==0.8.0
   - pip:
-    - unitpackage==0.8.0
     - bash_kernel

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,3 +9,5 @@ dependencies:
   - pip
   - python>=3.9,<3.11
   - unitpackage==0.8.0
+  - pip:
+    - bash_kernel

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,5 +8,4 @@ dependencies:
   - notebook
   - pip
   - python>=3.9,<3.11
-  - pip:
-    - unitpackage==0.8.0
+  - unitpackage==0.8.0

--- a/binder/labconfig/default_setting_overrides.json
+++ b/binder/labconfig/default_setting_overrides.json
@@ -1,0 +1,13 @@
+{
+    "@jupyterlab/docmanager-extension:plugin": {
+      "defaultViewers": {
+        "markdown": "Jupytext Notebook",
+        "myst": "Jupytext Notebook",
+        "r-markdown": "Jupytext Notebook",
+        "quarto": "Jupytext Notebook",
+        "julia": "Jupytext Notebook",
+        "python": "Jupytext Notebook",
+        "r": "Jupytext Notebook"
+      }
+    }
+  }

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,6 +8,3 @@ pip install .
 
 mkdir -p ${HOME}/.jupyter/labconfig
 cp binder/labconfig/* ${HOME}/.jupyter/labconfig
-
-# Install the bash kernel
-python -m bash_kernel.install

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,13 @@
+# Stop everything if one command fails
+set -e
+
+# Install from sources
+# NB: If you want to use Jupytext on your binder, don't install it from source,
+# just add "jupytext" to your "binder/requirements.txt" instead.
+pip install .
+
+mkdir -p ${HOME}/.jupyter/labconfig
+cp binder/labconfig/* ${HOME}/.jupyter/labconfig
+
+# Create the notebook for our jupytext demo
+jupytext doc/index.md --to ipynb --update-metadata '{"jupytext":null}'

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -9,8 +9,5 @@ pip install .
 mkdir -p ${HOME}/.jupyter/labconfig
 cp binder/labconfig/* ${HOME}/.jupyter/labconfig
 
-# Create the notebook for our jupytext demo
-jupytext doc/index.md --to ipynb --update-metadata '{"jupytext":null}'
-
 # Install the bash kernel
 python -m bash_kernel.install

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -11,3 +11,6 @@ cp binder/labconfig/* ${HOME}/.jupyter/labconfig
 
 # Create the notebook for our jupytext demo
 jupytext doc/index.md --to ipynb --update-metadata '{"jupytext":null}'
+
+# Install the bash kernel
+python -m bash_kernel.install

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,7 +14,7 @@ kernelspec:
 
 # Welcome to unitpackage's documentation!
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/0.8.0?urlpath=tree%2Fdoc%2Fusage%2Fentry_interactions.md)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/0.8.0?labpath=tree%2Fdoc%2index.md)
 [![DOI](https://zenodo.org/badge/637997870.svg)](https://zenodo.org/badge/latestdoi/637997870)
 
 Annotation of scientific data plays a crucial role in research data management workflows to ensure that the data is stored according to the FAIR principles. A simple CSV file recorded during an experiment usually does, for example, not provide any information on the units of the values within the CSV, nor does it provide information on what system has been investigated, or who performed the experiment. Such information can be stored in [frictionless datapackages](https://frictionlessdata.io/), which consist of a CSV (data) file which is annotated with a JSON file.

--- a/doc/news/binder.rst
+++ b/doc/news/binder.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed binder configuration files and links.

--- a/rever.xsh
+++ b/rever.xsh
@@ -1,7 +1,7 @@
 # ********************************************************************
 #  This file is part of unitpackage.
 #
-#        Copyright (C) 2022-2023 Albert Engstfeld
+#        Copyright (C) 2022-2024 Albert Engstfeld
 #        Copyright (C) 2022      Johannes Hermann
 #        Copyright (C) 2022      Julian Rüth
 #        Copyright (C) 2022      Nicolas Hörmann
@@ -51,8 +51,8 @@ $ACTIVITIES = [
 $VERSION_BUMP_PATTERNS = [
     ('setup.py', r"    version=", r'    version="$VERSION",'),
     ('doc/conf.py', r"release = ", r"release = '$VERSION'"),
-    ('doc/index.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?urlpath=tree%2Fdoc%2Fusage%2Fentry_interactions.md)"),
-    ('README.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?urlpath=tree%2Fdoc%2Fusage%2Fentry_interactions.md)"),
+    ('doc/index.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?labpath=tree%2Fdoc%2Findex.md)"),
+    ('README.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?labpath=tree%2Fdoc%2Findex.md)"),
     ('binder/environment.yml', r"    - unitpackage==", r"    - unitpackage==$VERSION"),
 ]
 

--- a/rever.xsh
+++ b/rever.xsh
@@ -53,7 +53,7 @@ $VERSION_BUMP_PATTERNS = [
     ('doc/conf.py', r"release = ", r"release = '$VERSION'"),
     ('doc/index.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?labpath=tree%2Fdoc%2Findex.md)"),
     ('README.md', re.escape(r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/"), r"[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/echemdb/unitpackage/$VERSION?labpath=tree%2Fdoc%2Findex.md)"),
-    ('binder/environment.yml', r"    - unitpackage==", r"    - unitpackage==$VERSION"),
+    ('binder/environment.yml', r"  - unitpackage==", r"  - unitpackage==$VERSION"),
 ]
 
 $CHANGELOG_FILENAME = 'ChangeLog'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.
* [x] Adapted the documentation for this change.

<!--
Please add any other relevant info below:
-->

Based on: https://github.com/mwouts/jupytext/tree/main/binder

Tested for this branch with: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/DunklesArchipel/unitpackage/binder?labpath=doc%2Findex.md)

The binder link will only work when the package is available on conda-forge

