### PR TITLE
Let frictionless handle naming resources

### DIFF
--- a/doc/news/slugify_names.rst
+++ b/doc/news/slugify_names.rst
@@ -1,0 +1,3 @@
+**Removed:**
+
+* Removed `unitpackage.local.collect_datapackage` since it is identical to frictionless `package = Package()`.

--- a/unitpackage/collection.py
+++ b/unitpackage/collection.py
@@ -343,9 +343,8 @@ class Collection:
             [Entry('engstfeld_2018_polycrystalline_17743_f4b_1')]
 
         """
-        from unitpackage.local import collect_datapackage
 
-        package = collect_datapackage(filename)
+        package = Package(filename)
 
         return cls(package=package)
 

--- a/unitpackage/entry.py
+++ b/unitpackage/entry.py
@@ -766,9 +766,9 @@ class Entry:
             Entry('no_bibliography')
 
         """
-        from unitpackage.local import collect_datapackage
+        from unitpackage.local import Package
 
-        package = collect_datapackage(filename)
+        package = Package(filename)
 
         if len(package.resources) == 0:
             raise ValueError(f"No resource available in '{filename}'")

--- a/unitpackage/local.py
+++ b/unitpackage/local.py
@@ -68,23 +68,6 @@ def create_df_resource(resource):
     return df_resource
 
 
-def collect_datapackage(filename):
-    r"""
-    Return a Data Package from a :param filename which must be a valid frictionless Data Package (JSON).
-
-    EXAMPLES::
-
-        >>> package = collect_datapackage("./examples/local/no_bibliography/no_bibliography.json")
-        >>> package # doctest: +NORMALIZE_WHITESPACE
-        {'resources': [{'name':
-        ...
-
-    """
-    package = Package(filename)
-
-    return package
-
-
 def collect_resources(datapackages):
     r"""
     Return a list of resources from a list of Data Packages.
@@ -120,7 +103,7 @@ def collect_datapackages(data):
     """
     packages = sorted(glob(os.path.join(data, "**", "*.json"), recursive=True))
 
-    return [collect_datapackage(package) for package in packages]
+    return [Package(package) for package in packages]
 
 
 def create_unitpackage(csvname, metadata=None, fields=None):


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.
* [x] Adapted the documentation for this change.

<!--
Please add any other relevant info below:
-->

This relates to #76 
Now, it uses the frictionless interface to handle resource naming. Also obsolete methods were removed, and code refactored (no breaking changes).

