### PR TITLE
Improve loading speed of the database description

### DIFF
--- a/doc/news/describe-perfromance.rst
+++ b/doc/news/describe-perfromance.rst
@@ -1,0 +1,3 @@
+**Performance:**
+
+* Improved speed to return the echemdb description by caching the bibliography data.

--- a/unitpackage/database/echemdb.py
+++ b/unitpackage/database/echemdb.py
@@ -154,7 +154,10 @@ class Echemdb(Collection):
         # Parse each unique bibdata string only once; many entries share a publication.
         seen_citations = {}
         for entry in self:
-            citation = entry._default_metadata.get("source", {}).get("bibdata", "")
+            try:
+                citation = entry.source.bibdata
+            except AttributeError:
+                citation = ""
             if citation and citation not in seen_citations:
                 seen_citations[citation] = parse_string(citation, "bibtex")
 

--- a/unitpackage/database/echemdb.py
+++ b/unitpackage/database/echemdb.py
@@ -149,24 +149,22 @@ class Echemdb(Collection):
             ''
 
         """
-        from pybtex.database import BibliographyData
+        from pybtex.database import BibliographyData, parse_string
 
-        bib_data = BibliographyData(
-            {
-                entry.bibliography.key: entry.bibliography
-                for entry in self
-                if entry.bibliography
-            }
-        )
+        # Parse each unique bibdata string only once; many entries share a publication.
+        seen_citations = {}
+        for entry in self:
+            citation = entry._default_metadata.get("source", {}).get("bibdata", "")
+            if citation and citation not in seen_citations:
+                seen_citations[citation] = parse_string(citation, "bibtex")
 
-        if isinstance(bib_data, str):
-            return bib_data
+        if not seen_citations:
+            return ""
 
-        # Remove duplicates from the bibliography
         bib_data_ = BibliographyData()
-
-        for key, entry in bib_data.entries.items():
-            if key not in bib_data_.entries:
-                bib_data_.add_entry(key, entry)
+        for parsed in seen_citations.values():
+            for key, bib_entry in parsed.entries.items():
+                if key not in bib_data_.entries:
+                    bib_data_.add_entry(key, bib_entry)
 
         return bib_data_

--- a/unitpackage/database/echemdb.py
+++ b/unitpackage/database/echemdb.py
@@ -167,7 +167,6 @@ class Echemdb(Collection):
         bib_data_ = BibliographyData()
         for parsed in seen_citations.values():
             for key, bib_entry in parsed.entries.items():
-                if key not in bib_data_.entries:
-                    bib_data_.add_entry(key, bib_entry)
+                bib_data_.add_entry(key, bib_entry)
 
         return bib_data_

--- a/unitpackage/database/echemdb_entry.py
+++ b/unitpackage/database/echemdb_entry.py
@@ -65,6 +65,7 @@ where ``I`` or. ``j`` is plotted vs. ``U`` or. ``E``::
 #  along with unitpackage. If not, see <https://www.gnu.org/licenses/>.
 # ********************************************************************
 import logging
+from functools import cached_property
 
 from unitpackage.entry import Entry
 
@@ -174,7 +175,7 @@ class EchemdbEntry(Entry):
 
         return entry
 
-    @property
+    @cached_property
     def bibliography(self):
         r"""
         Return a pybtex bibliography object associated with this entry.


### PR DESCRIPTION
Previously the bibliohraphy data for each entry would have been called multiple times. Caching of literature data removed part of the issue. In addition we record for each entry its bibkey and only look up the bibliography if the data is not available.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [ x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [-] Added a test for this change.
* [-] Adapted the documentation for this change.

<!--
Please add any other relevant info below:
-->

