### PR TITLE
Allow version selection on dataset download

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -25,7 +25,7 @@ The website shows a collection of electrochemical data stored following in the [
 ## Examples
 
 A collection of [entries can be generated](usage/load_and_save.md) from local files or from a remote repository, such as [echemdb.org](https://www.echemdb.org). To illustrate the usage of `unitpackage`,
-we collect the data to [echemdb.org](https://www.echemdb.org/cv) from the data repository, which is downloaded by default when the method `from_remote()` does not receive a URL argument.
+we collect the data to [echemdb.org](https://www.echemdb.org/cv) from the data repository, which is downloaded by default when the method `from_remote()` does not receive any arguments. A specific version can be selected with `Echemdb.from_remote(version="0.8.2")`.
 
 ```{note}
 For simplicity, we denote the collection as `db` (database), even though it is not a database in that sense.

--- a/doc/news/select-dataset-version.rst
+++ b/doc/news/select-dataset-version.rst
@@ -1,0 +1,12 @@
+**Added:**
+
+* Added ``Echemdb.from_remote(version=...)`` to download a specific version of the echemdb database. The version is defined as ``ECHEMDB_DATABASE_VERSION`` in ``remote.py`` and serves as the single source of truth.
+
+**Changed:**
+
+* Changed ``Collection.from_remote`` to log the URL it downloads data from.
+* Changed argument order in ``Collection.from_remote``, ``Echemdb.from_remote``, and ``collect_datapackages``: ``outdir`` now comes before ``data``.
+
+**Removed:**
+
+* Removed ``ECHEMDB_DATABASE_URL`` module-level constant from ``remote.py``; use ``get_echemdb_database_url()`` instead.

--- a/doc/usage/echemdb_usage.md
+++ b/doc/usage/echemdb_usage.md
@@ -22,6 +22,12 @@ db = Echemdb.from_remote()
 type(db)
 ```
 
+A specific version of the database can be downloaded by providing a `version` argument.
+
+```{code-cell} ipython3
+db = Echemdb.from_remote(version='0.8.4')
+```
+
 ## Collection
 
 In contrast to the `Collection` object described in the [usage section](unitpackage_usage.md), `Echemdb` provides data specific functionality.

--- a/doc/usage/load_and_save.md
+++ b/doc/usage/load_and_save.md
@@ -66,7 +66,7 @@ A parameter `data` allows specifying the folder within the ZIP containing the da
 ```{code-cell} ipython3
 from unitpackage.collection import Collection
 
-db = Collection.from_remote(data='data', outdir='generated/from_url')
+db = Collection.from_remote(outdir='generated/from_url', data='data')
 ```
 
 ## Load entries

--- a/unitpackage/collection.py
+++ b/unitpackage/collection.py
@@ -545,7 +545,7 @@ class Collection:
         return cls(package=package)
 
     @classmethod
-    def from_remote(cls, url=None, data=None, outdir=None):
+    def from_remote(cls, url=None, outdir=None, data=None):
         r"""
         Create a collection from a url containing a zip.
 
@@ -560,24 +560,18 @@ class Collection:
             >>> collection.filter(lambda entry: entry.echemdb.source.url == 'https://doi.org/10.1039/C0CP01001D')   # doctest: +REMOTE_DATA
             [Entry('alves_2011_electrochemistry_6010_f1a_solid'), Entry('alves_2011_electrochemistry_6010_f2_red')]
 
-        The folder containing the data in the zip can be specified with the :param data:.
         An output directory for the extracted data can be specified with the :param outdir:.
+        The folder containing the data in the zip can be specified with the :param data:.
         """
         import unitpackage.local
         import unitpackage.remote
 
-        package = Package()
-
         if url is None:
-            data_packages = unitpackage.remote.collect_datapackages(
-                data=data, outdir=outdir
-            )
-            resources = unitpackage.local.collect_resources(data_packages)
+            url = unitpackage.remote.get_echemdb_database_url()
 
-            for resource in resources:
-                package.add_resource(resource)
+        logger.info("Downloading data from '%s'.", url)
 
-            return cls(package=package)
+        package = Package()
 
         data_packages = unitpackage.remote.collect_datapackages(
             url=url, data=data, outdir=outdir

--- a/unitpackage/database/echemdb.py
+++ b/unitpackage/database/echemdb.py
@@ -72,6 +72,34 @@ class Echemdb(Collection):
 
     Entry = EchemdbEntry
 
+    @classmethod
+    def from_remote(cls, url=None, outdir=None, data=None, version=None):
+        r"""
+        Create an Echemdb collection from the echemdb data repository.
+
+        EXAMPLES::
+
+            >>> from unitpackage.database.echemdb import Echemdb
+            >>> collection = Echemdb.from_remote()  # doctest: +REMOTE_DATA
+            >>> collection.filter(lambda entry: entry.source.url == 'https://doi.org/10.1039/C0CP01001D')  # doctest: +REMOTE_DATA
+            [Echemdb('alves_2011_electrochemistry_6010_f1a_solid'), ...
+
+        A specific version of the database can be retrieved with the ``version`` argument::
+
+            >>> collection = Echemdb.from_remote(version='0.5.0')  # doctest: +REMOTE_DATA
+
+        """
+        from unitpackage.remote import (
+            ECHEMDB_DATABASE_VERSION,
+            get_echemdb_database_url,
+        )
+
+        if url is None:
+            if version is None:
+                version = ECHEMDB_DATABASE_VERSION
+            url = get_echemdb_database_url(version=version)
+        return super().from_remote(url=url, data=data, outdir=outdir)
+
     def materials(self):
         r"""
         Return the substrate materials in the collection.

--- a/unitpackage/remote.py
+++ b/unitpackage/remote.py
@@ -27,14 +27,25 @@ Utilities to work with remote Data Packages.
 import os.path
 from functools import cache
 
-ECHEMDB_DATABASE_URL = os.environ.get(
-    "ECHEMDB_DATABASE_URL",
-    "https://github.com/echemdb/electrochemistry-data/releases/download/0.5.0/data-0.5.0.zip",
-)
+ECHEMDB_DATABASE_VERSION = "0.5.0"
+
+
+def get_echemdb_database_url(version=ECHEMDB_DATABASE_VERSION):
+    r"""
+    Return the URL of the database to retrieve data packages from.
+
+    By default, this is the URL of the ZIP file containing the data packages currently available on `echemdb <https://www.echemdb.org/cv>`_
+    which are retrieved from `the echemdb electrochemistry-data repository <https://github.com/echemdb/electrochemistry-data>`_.
+
+    """
+    return os.environ.get(
+        "ECHEMDB_DATABASE_URL",
+        f"https://github.com/echemdb/electrochemistry-data/releases/download/{version}/data-{version}.zip",
+    )
 
 
 @cache
-def collect_zipfile_from_url(url=ECHEMDB_DATABASE_URL):
+def collect_zipfile_from_url(url=None):
     r"""
     Download a ZIP file from ``url`` and return it as a temporary object to
     extract contents from.
@@ -49,7 +60,7 @@ def collect_zipfile_from_url(url=ECHEMDB_DATABASE_URL):
 
 
 @cache
-def collect_datapackages(data=None, url=ECHEMDB_DATABASE_URL, outdir=None):
+def collect_datapackages(url=None, outdir=None, data=None):
     r"""
     Return a list of data packages defined in a remote location.
 
@@ -64,6 +75,9 @@ def collect_datapackages(data=None, url=ECHEMDB_DATABASE_URL, outdir=None):
         >>> packages = collect_datapackages()  # doctest: +REMOTE_DATA
 
     """
+    if url is None:
+        url = get_echemdb_database_url()
+
     if outdir is None:
         import atexit
         import shutil


### PR DESCRIPTION
The version of the dataset to be downloaded from the electrochemistry-data repository, can now be set specifically.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.
* [x] Adapted the documentation for this change.

<!--
Please add any other relevant info below:
-->

